### PR TITLE
Fix/get mem time eval python

### DIFF
--- a/app/jobs/evaluate_python_job.rb
+++ b/app/jobs/evaluate_python_job.rb
@@ -12,7 +12,6 @@ class EvaluatePythonJob < ActiveJob::Base
     work_dir = "#{root_dir}/tmp/answers" # 作業ディレクトリ
     work_filename = "#{user_id}_#{lesson_id}_#{question_id}" # 作業用ファイル名接頭辞
     spec_file = "#{work_dir}/#{work_filename}_spec" # 実行時間とメモリ使用量記述ファイル
-    spec_file_tmp = "#{work_dir}/#{work_filename}_spec_tmp" # 実行時間とメモリ使用量記述ファイル
 
     question = Question.find_by(:id => question_id)
     run_time_limit = question.run_time_limit || 5 # 実行時間が未設定ならば5秒
@@ -23,7 +22,6 @@ class EvaluatePythonJob < ActiveJob::Base
     test_count = test_data.size
     original_file = "#{root_dir}/uploads/#{user_id}/#{lesson_id}/#{question_id}/#{answer.file_name}" # アップロードされたファイル
     exe_file = "#{work_dir}/#{work_filename}_exe.py" # 追記後の実行ファイル
-    @max_pss = 0
 
     FileUtils.mkdir_p(work_dir) unless FileTest.exist?(work_dir)
     FileUtils.copy(original_file, exe_file)
@@ -42,46 +40,26 @@ class EvaluatePythonJob < ActiveJob::Base
 
     # テストデータの数だけ繰り返し
     1.upto(test_count) do |i|
-      exec_cmd = "python3 #{exe_file} < #{work_dir}/#{work_filename}_input#{i} > #{work_dir}/#{work_filename}_result#{i}"
+      exec_cmd = "ts=$(date +%s%N); (/usr/bin/time -f '%M' python3 #{exe_file} < #{work_dir}/#{work_filename}_input#{i} > #{work_dir}/#{work_filename}_result#{i}) 2> #{spec_file}; tt=$((($(date +%s%N) - $ts)/1000000)); echo $tt >> #{spec_file}"
 
       begin
         Timeout.timeout(run_time_limit) do
-          start_time = Time.now.instance_eval { self.to_i * 1000 + (usec/1000) }
           # 入力用ファイルを入力し，結果をファイル出力
           @process = IO.popen(exec_cmd)
-
-          # PSSの更新とプロセスチェック
-          loop do
-            # PSSの更新
-            tmp = `cat /proc/#{@process.pid}/smaps 2> /dev/null | awk '/^Pss/{sum += $2}END{print sum}'`.to_i
-            @max_pss = tmp if tmp > @max_pss
-
-            # 処理の終了チェック
-            begin
-              Timeout.timeout 0.000001 do
-                Process.waitpid2(@process.pid)
-                break
-              end
-            rescue Timeout::Error
-            rescue Errno::ECHILD
-              @elapsed_time = Time.now.instance_eval { self.to_i * 1000 + (usec/1000) } - start_time
-              break
-            end
-          end
+          Process.waitpid2(@process.pid)
         end
 
         # 処理中にタイムアウトになった場合
       rescue Timeout::Error => e
         # Rubyのプロセス管理の理由からpid + 1
-        Process.kill(:KILL, @process.pid + 1)
-        puts "kill timeout process #{@process.pid}"
+        Process.kill(:KILL, @process.pid + 3)
+        puts "kill timeout process #{@process.pid + 3}"
         cancel_evaluate(answer, "TO", "#{work_dir}/#{work_filename}")
         return
       end
 
       # 結果と出力用ファイルのdiff
       result = `diff #{work_filename}_output#{i} #{work_filename}_result#{i}`
-      logger.debug("test")
 
       # diff結果が異なればそこでテスト失敗
       unless result.empty?
@@ -90,8 +68,14 @@ class EvaluatePythonJob < ActiveJob::Base
       end
 
       # 実行時間とメモリ使用量を記録
-      spec[i][:time] = @elapsed_time
-      spec[i][:memory] = @max_pss
+      memory = 0
+      time = 0
+      File.open(spec_file, "r") do |f|
+        memory = f.gets
+        time = f.gets
+      end
+      spec[i][:memory] = memory
+      spec[i][:time] = time
     end
 
     # 最大値を求めるためのソート


### PR DESCRIPTION
python実行時のメモリ使用量と実行時間取得方法を変更．
ShellScriptを活用したので別の言語の場合にも使用できるはず．
