### PR TITLE
Fix javascript not to allow all delete form of questions#new's sample…

### DIFF
--- a/app/assets/javascripts/questions/nested_form.js
+++ b/app/assets/javascripts/questions/nested_form.js
@@ -1,0 +1,16 @@
+/**
+ * Created by lin on 15/07/13.
+ */
+$(document).on('nested:fieldRemoved', function(event){
+    var field = event.field;
+    var parent = field.parent();
+    var id = parent[0].id;
+    console.log($('#' + id).find('.fields'));
+    console.log($('#' + id).find('.fields').length);
+    console.log($('#' + id).find('.fields').length == 1);
+    if($('#' + id).find('.fields').length != 1){
+        field.remove();
+    } else {
+        field.css("display", "");
+    }
+});

--- a/app/assets/javascripts/questions/net_form_user.js
+++ b/app/assets/javascripts/questions/net_form_user.js
@@ -1,7 +1,0 @@
-/**
- * Created by lin on 15/07/13.
- */
-$(document).on('nested:fieldRemoved', function(event){
-    var field = event.field;
-    field.remove();
-});

--- a/app/views/questions/_new.html.erb
+++ b/app/views/questions/_new.html.erb
@@ -36,7 +36,7 @@
       </div>
 
       <div class="field_question">
-        <fieldset>
+        <fieldset id="samples">
           <legend>入出力サンプル(<span class="inputnote">＊</span>)</legend>
           <%= f.fields_for :samples do |builder| %>
 
@@ -52,7 +52,7 @@
       </div>
 
       <div class="field_question">
-        <fieldset>
+        <fieldset id="test_data">
           <legend>解答用データ(<span class="inputnote">＊</span>)</legend>
           <%= f.fields_for :test_data do |builder| %>
             <div class="left">


### PR DESCRIPTION
# 概要
- 問題作成時に，すべてのサンプルや解答データを削除した状態で登録できる問題を対応
- サンプルと解答用データのフォームが1つの場合は削除できないようにする．
# 変更点
- nested_form用のjavascriptを修正
  - フォームが１つの場合は削除を行わない
  - `display:none` になるものを再び表示する
