### PR TITLE
Feature/jobs on docker in c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 .env
 /uploads/*
 ,/*
+/docker/*

--- a/app/jobs/evaluate_c_job.rb
+++ b/app/jobs/evaluate_c_job.rb
@@ -8,10 +8,8 @@ class EvaluateCJob < ActiveJob::Base
   # @param [Fixnum] lesson_id 授業ID
   # @param [Fixnum] question_id 問題ID
   def perform(user_id:, lesson_id:, question_id:)
-    # ファイル名やファイル場所の設定
-    work_filename = "#{user_id}_#{lesson_id}_#{question_id}" # 作業用ファイル名接頭辞
-    work_dir_file = EVALUATE_WORK_DIR.join(work_filename) # 接頭辞
-    spec_file = "#{work_dir_file}_spec" # 実行時間とメモリ使用量記述ファイル
+    # 作業ディレクトリ名を乱数で生成
+    dir_name = EVALUATE_WORK_DIR.to_s + "/" + Digest::MD5.hexdigest(DateTime.now.to_s + rand.to_s)
 
     question = Question.find_by(:id => question_id)
     run_time_limit = question.run_time_limit.to_f / 1000
@@ -25,16 +23,22 @@ class EvaluateCJob < ActiveJob::Base
     test_data_dir = UPLOADS_QUESTIONS_PATH.join(question_id.to_s)
     # アップロードされたファイル
     original_file = UPLOADS_ANSWERS_PATH.join(user_id.to_s, lesson_id.to_s, question_id.to_s, answer.file_name)
-    src_file = "#{work_dir_file}_src#{ext}" # コンパイル前のソースファイル
-    exe_file = "#{work_dir_file}_exe" # コンパイル前のソースファイル
+    src_file = "cpp_src#{ext}" # コンパイル前のソースファイル
+    exe_file = "cpp_exe" # コンパイル後のソースファイル
 
-    FileUtils.mkdir_p(EVALUATE_WORK_DIR) unless FileTest.exist?(EVALUATE_WORK_DIR)
+    # 作業ディレクトリの作成
+    FileUtils.mkdir_p(dir_name) unless FileTest.exist?(dir_name)
+    # 作業ディレクトリへ移動
+    Dir.chdir(dir_name)
+
+    # 作業ディレクトリにプログラムとテストデータをコピー
     FileUtils.copy(original_file, src_file)
+    FileUtils.copy(Dir.glob(test_data_dir.to_s + "/*"), ".")
 
-    Dir.chdir(EVALUATE_WORK_DIR)
     spec = Hash.new { |h,k| h[k] = {} }
+    containers = []
 
-    compile_cmd = "g++ #{src_file} -o #{exe_file} -w"
+    compile_cmd = "g++ #{src_file} -o #{dir_name}/#{exe_file} -w"
     # コンパイル
     @compile = IO.popen(compile_cmd, :err => [:child, :out])
 
@@ -47,66 +51,76 @@ class EvaluateCJob < ActiveJob::Base
     # コンパイルエラー時
     unless compile_error.empty?
       puts "Complilation Error"
-      cancel_evaluate(answer, "CE", "#{work_dir_file}")
+      cancel_evaluate(answer, "CE", "#{dir_name}")
       return
     end
     Process.waitpid2(@compile.pid)
 
     # テストデータの数だけ試行
-    1.upto(test_count) do |i|
-      result = "P"
-      memory = 0
-      time = 0
-      spec[i][:result] = result
-      spec[i][:memory] = memory
-      spec[i][:time] = time
+    begin
+      t = Thread.new do
+        1.upto(test_count) do |i|
+          result = "P"
+          memory = 0
+          time = 0
+          spec[i][:result] = result
+          spec[i][:memory] = memory
+          spec[i][:time] = time
 
-      exec_cmd = "ts=$(date +%s%N); (/usr/bin/time -f '%M' #{exe_file} < #{test_data_dir}/input#{i} > #{work_dir_file}_result#{i}) 2> #{spec_file}; tt=$((($(date +%s%N) - $ts)/1000000)); echo $tt >> #{spec_file}"
+          container_name = Digest::MD5.hexdigest(DateTime.now.to_s + rand.to_s)
+          containers.push(container_name)
 
-      begin
-        # 実行時間制限
-        Timeout.timeout(run_time_limit) do
-          # 入力用ファイルを入力し，結果をファイル出力
-          @exec = IO.popen(exec_cmd)
-          Process.waitpid2(@exec.pid)
+          # dockerコンテナでプログラムを実行
+          exec_cmd = "docker run --name #{container_name} -e NUM=#{i} -e EXE=#{exe_file} -v #{dir_name}:/home/test_user/work procs/cpp_sandbox"
+
+          begin
+            # 実行時間制限
+            Timeout.timeout(run_time_limit) do
+              # 入力用ファイルを入力し，結果をファイル出力
+              @exec = IO.popen(exec_cmd)
+              Process.waitpid2(@exec.pid)
+            end
+
+          rescue Timeout::Error
+            `docker kill #{container_name}`
+            puts "Kill timeout container #{container_name}"
+            puts "Time Limit Exceeded"
+            spec[i][:result] = "TLE"
+            next
+          end
+
+          # 結果と出力用ファイルのdiff
+          diff = `diff output#{i} result#{i}`
+
+          # diff結果が異なればそこでテスト失敗
+          unless diff.empty?
+            puts "Wrong Answer"
+            spec[i][:result] = "WA"
+            next
+          end
+
+          # 実行時間とメモリ使用量を記録
+          File.open("spec#{i}", "r") do |f|
+            memory = f.gets.to_i
+            utime = f.gets.to_f
+            stime = f.gets.to_f
+            time = (utime + stime) * 1000
+          end
+
+          if (memory / 1024) > memory_usage_limit
+            puts "Memory Limit Exceeded"
+            spec[i][:result] = "MLE"
+            next
+          end
+
+          spec[i][:result] = "A"
+          spec[i][:memory] = memory
+          spec[i][:time] = time
         end
-
-      rescue Timeout::Error
-        # 複数のプロセスを実行するため pid + 3
-        Process.kill(:KILL, @exec.pid + 3)
-        puts "Kill timeout process #{@exec.pid + 3}"
-        puts "Time Limit Exceeded"
-        spec[i][:result] = "TLE"
-        next
       end
-
-      # 結果と出力用ファイルのdiff
-      result = `diff #{test_data_dir}/output#{i} #{work_filename}_result#{i}`
-
-      # diff結果が異なればそこでテスト失敗
-      unless result.empty?
-        puts "Wrong Answer"
-        spec[i][:result] = "WA"
-        next
-      end
-
-      # 実行時間とメモリ使用量を記録
-      memory = 0
-      time = 0
-      File.open(spec_file, "r") do |f|
-        memory = f.gets.to_i
-        time = f.gets.to_i
-      end
-
-      if (memory / 1024) > memory_usage_limit
-        puts "Memory Limit Exceeded"
-        spec[i][:result] = "MLE"
-        next
-      end
-
-      spec[i][:result] = "A"
-      spec[i][:memory] = memory
-      spec[i][:time] = time
+      t.join
+    rescue
+      pp $!
     end
 
     # 最大値を求めるためのソート
@@ -138,7 +152,13 @@ class EvaluateCJob < ActiveJob::Base
     answer.test_passed = passed
     answer.test_count = test_count
     answer.save
-    `rm #{work_dir_file}*`
+
+    # コンテナの削除
+    containers.each {|c| `docker rm #{c}`}
+
+    # 作業ディレクトリの削除
+    Dir.chdir("..")
+    `rm -r #{dir_name}`
     return
   end
 end

--- a/app/jobs/evaluate_c_job.rb
+++ b/app/jobs/evaluate_c_job.rb
@@ -34,7 +34,7 @@ class EvaluateCJob < ActiveJob::Base
     Dir.chdir(EVALUATE_WORK_DIR)
     spec = Hash.new { |h,k| h[k] = {} }
 
-    compile_cmd = "gcc #{src_file} -o #{exe_file} -w"
+    compile_cmd = "g++ #{src_file} -o #{exe_file} -w"
     # コンパイル
     @compile = IO.popen(compile_cmd, :err => [:child, :out])
 

--- a/app/jobs/evaluate_python_job.rb
+++ b/app/jobs/evaluate_python_job.rb
@@ -44,7 +44,6 @@ class EvaluatePythonJob < ActiveJob::Base
     begin
       t = Thread.new do
         1.upto(test_count) do |i|
-          pp "start #{i}"
           result = "P"
           memory = 0
           time = 0
@@ -91,10 +90,6 @@ class EvaluatePythonJob < ActiveJob::Base
             utime = f.gets.to_f
             stime = f.gets.to_f
             time = (utime + stime) * 1000
-        puts "memory = #{memory}"
-        puts "utime = #{utime}"
-        puts "stime = #{stime}"
-        puts "time = #{time}"
           end
 
           if (memory / 1024) > memory_usage_limit

--- a/app/jobs/evaluate_python_job.rb
+++ b/app/jobs/evaluate_python_job.rb
@@ -2,16 +2,15 @@
 class EvaluatePythonJob < ActiveJob::Base
   queue_as :evaluate
   include EvaluateProgram
+  EVAL_ENV = "docker" # 検証用の環境変数
 
   # pythonプログラムの評価実行
   # @param [Fixnum] user_id ユーザID
   # @param [Fixnum] lesson_id 授業ID
   # @param [Fixnum] question_id 問題ID
   def perform(user_id:, lesson_id:, question_id:)
-    # ファイル名やファイル場所の設定
-    work_filename = "#{user_id}_#{lesson_id}_#{question_id}" # 作業用ファイル名接頭辞
-    work_dir_file = EVALUATE_WORK_DIR.join(work_filename) # 接頭辞
-    spec_file = "#{work_dir_file}_spec" # 実行時間とメモリ使用量記述ファイル
+    # 作業ディレクトリ名を乱数で生成
+    dir_name = EVALUATE_WORK_DIR.to_s + "/" + Digest::MD5.hexdigest(DateTime.now.to_s + rand.to_s)
 
     question = Question.find_by(:id => question_id)
     run_time_limit = question.run_time_limit.to_f / 1000
@@ -23,16 +22,23 @@ class EvaluatePythonJob < ActiveJob::Base
     test_data = TestDatum.where(:question_id => question_id)
     test_count = test_data.size
     test_data_dir = UPLOADS_QUESTIONS_PATH.join(question_id.to_s)
+
     # アップロードされたファイル
     original_file = UPLOADS_ANSWERS_PATH.join(user_id.to_s, lesson_id.to_s, question_id.to_s, answer.file_name)
 
-    exe_file = "#{work_dir_file}_exe#{ext}" # 追記後の実行ファイル
+    exe_file = "python#{ext}" # 追記後の実行ファイル
 
-    FileUtils.mkdir_p(EVALUATE_WORK_DIR) unless FileTest.exist?(EVALUATE_WORK_DIR)
+    # 作業ディレクトリの作成
+    FileUtils.mkdir_p(dir_name) unless FileTest.exist?(dir_name)
+    # 作業ディレクトリへ移動
+    Dir.chdir(dir_name)
+
+    # 作業ディレクトリにプログラムとテストデータをコピー
     FileUtils.copy(original_file, exe_file)
+    FileUtils.copy(Dir.glob(test_data_dir.to_s + "/*"), ".")
 
-    Dir.chdir(EVALUATE_WORK_DIR)
     spec = Hash.new { |h,k| h[k] = {} }
+    containers = []
 
     # テストデータの数だけ繰り返し
     1.upto(test_count) do |i|
@@ -43,7 +49,11 @@ class EvaluatePythonJob < ActiveJob::Base
       spec[i][:memory] = memory
       spec[i][:time] = time
 
-      exec_cmd = "ts=$(date +%s%N); (/usr/bin/time -f '%M' python3 #{exe_file} < #{test_data_dir}/input#{i} > #{work_dir_file}_result#{i}) 2> #{spec_file}; tt=$((($(date +%s%N) - $ts)/1000000)); echo $tt >> #{spec_file}"
+      # コンテナ名を乱数のハッシュで生成
+      container_name = Digest::MD5.hexdigest(DateTime.now.to_s + rand.to_s)
+      containers.push(container_name)
+      # dockerコンテナでプログラムを実行
+      exec_cmd = "docker run --name #{container_name} -e NUM=#{i} -e EXE=#{exe_file} -v #{dir_name}:/home/test_user/work errorcode/python_sandbox"
 
       begin
         # 実行時間制限
@@ -55,16 +65,15 @@ class EvaluatePythonJob < ActiveJob::Base
 
         # 処理中にタイムアウトになった場合
       rescue Timeout::Error
-        # 複数のプロセスを実行するため pid + 3
-        Process.kill(:KILL, @exec.pid + 3)
-        puts "Kill timeout process #{@exec.pid + 3}"
+        `docker kill #{container_name}`
+        puts "Kill timeout container #{container_name}"
         puts "Time Limit Exceeded"
         spec[i][:result] = "TLE"
         next
       end
 
       # 結果と出力用ファイルのdiff
-      diff = `diff #{test_data_dir}/output#{i} #{work_filename}_result#{i}`
+      diff = `diff output#{i} result#{i}`
 
       # diff結果が異なればそこでテスト失敗
       unless diff.empty?
@@ -74,7 +83,7 @@ class EvaluatePythonJob < ActiveJob::Base
       end
 
       # 実行時間とメモリ使用量を記録
-      File.open(spec_file, "r") do |f|
+      File.open("spec#{i}", "r") do |f|
         memory = f.gets.to_i
         time = f.gets.to_i
       end
@@ -119,7 +128,13 @@ class EvaluatePythonJob < ActiveJob::Base
     answer.test_passed = passed
     answer.test_count = test_count
     answer.save
-    `rm #{work_dir_file}*`
+
+    # コンテナの削除
+    containers.each {|c| `docker rm #{c}`}
+
+    # 作業ディレクトリの削除
+    Dir.chdir("..")
+    `rm -r #{dir_name}`
     return
   end
 end

--- a/app/jobs/evaluate_python_job.rb
+++ b/app/jobs/evaluate_python_job.rb
@@ -53,7 +53,7 @@ class EvaluatePythonJob < ActiveJob::Base
       container_name = Digest::MD5.hexdigest(DateTime.now.to_s + rand.to_s)
       containers.push(container_name)
       # dockerコンテナでプログラムを実行
-      exec_cmd = "docker run --name #{container_name} -e NUM=#{i} -e EXE=#{exe_file} -v #{dir_name}:/home/test_user/work errorcode/python_sandbox"
+      exec_cmd = "docker run --name #{container_name} -e NUM=#{i} -e EXE=#{exe_file} -v #{dir_name}:/home/test_user/work procs/python_sandbox"
 
       begin
         # 実行時間制限
@@ -85,7 +85,9 @@ class EvaluatePythonJob < ActiveJob::Base
       # 実行時間とメモリ使用量を記録
       File.open("spec#{i}", "r") do |f|
         memory = f.gets.to_i
-        time = f.gets.to_i
+        utime = f.gets.to_f
+        stime = f.gets.to_f
+        time = (utime + stime) * 1000.0
       end
 
       if (memory / 1024) > memory_usage_limit

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,15 +30,5 @@ module Procs
     config.active_job.queue_adapter = :sidekiq
     config.assets.compile =true
 
-    config.after_initialize do
-      FileUtils.mkdir_p(DOCKER_PATH) unless FileTest.exist?(DOCKER_PATH)
-      if FileTest.exist?("#{DOCKER_PATH}/.git")
-        Dir.chdir(DOCKER_PATH)
-        `git pull `#https://github.com/m-oke/TKB-procon_sandbox.git `
-      else
-        `git clone https://github.com/m-oke/TKB-procon_sandbox.git #{DOCKER_PATH}`
-      end
-      `docker build -t procs/python_sandbox #{DOCKER_PATH}/python_sandbox`
-    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,15 @@ module Procs
     config.active_job.queue_adapter = :sidekiq
     config.assets.compile =true
 
+    config.after_initialize do
+      FileUtils.mkdir_p(DOCKER_PATH) unless FileTest.exist?(DOCKER_PATH)
+      if FileTest.exist?("#{DOCKER_PATH}/.git")
+        Dir.chdir(DOCKER_PATH)
+        `git pull `#https://github.com/m-oke/TKB-procon_sandbox.git `
+      else
+        `git clone https://github.com/m-oke/TKB-procon_sandbox.git #{DOCKER_PATH}`
+      end
+      `docker build -t procs/python_sandbox #{DOCKER_PATH}/python_sandbox`
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,10 +81,11 @@ Rails.application.configure do
     FileUtils.mkdir_p(DOCKER_PATH) unless FileTest.exist?(DOCKER_PATH)
     if FileTest.exist?("#{DOCKER_PATH}/.git")
       Dir.chdir(DOCKER_PATH)
-        `git pull `#https://github.com/m-oke/TKB-procon_sandbox.git `
+      `git pull`
     else
       `git clone https://github.com/m-oke/TKB-procon_sandbox.git #{DOCKER_PATH}`
     end
     `docker build -t procs/python_sandbox #{DOCKER_PATH}/python_sandbox`
+    `docker build -t procs/cpp_sandbox #{DOCKER_PATH}/cpp_sandbox`
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,15 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.after_initialize do
+    FileUtils.mkdir_p(DOCKER_PATH) unless FileTest.exist?(DOCKER_PATH)
+    if FileTest.exist?("#{DOCKER_PATH}/.git")
+      Dir.chdir(DOCKER_PATH)
+        `git pull `#https://github.com/m-oke/TKB-procon_sandbox.git `
+    else
+      `git clone https://github.com/m-oke/TKB-procon_sandbox.git #{DOCKER_PATH}`
+    end
+    `docker build -t procs/python_sandbox #{DOCKER_PATH}/python_sandbox`
+  end
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -6,3 +6,4 @@ UPLOADS_PATH = Rails.root.join('uploads') # ファイルアップロードディ
 UPLOADS_ANSWERS_PATH = UPLOADS_PATH.join("answers") # 解答ファイルのアップロードディレクトリ
 UPLOADS_QUESTIONS_PATH = UPLOADS_PATH.join("questions") # 問題のテストデータアップロードディレクトリ
 EVALUATE_WORK_DIR = Rails.root.join("tmp", "answers") # 評価時の作業ディレクトリ
+DOCKER_PATH = Rails.root.join("docker") # Dockerイメージ用のパス

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` on Rails 4+ applications as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = 'd60beb825a2bf291dca0b9cb67538821334a1d53800443292f37282d44831aa1f96ee3c5b68b3a63afc92d57b0df8c196eb4a98b8a5d9e7055d0b92cdfca8e29'
+  config.secret_key = '463223e3a1cb83f469011c9b0b0f865a9f45c1371128539b5a5c64046403fcc2d888b74c7c63f14bb0c60f5d8d996b3aff399bb2ccafb32151be47890f9ad0b8'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/db/migrate/20151005063504_change_type_of_answer_run_time_to_integer.rb
+++ b/db/migrate/20151005063504_change_type_of_answer_run_time_to_integer.rb
@@ -1,0 +1,5 @@
+class ChangeTypeOfAnswerRunTimeToInteger < ActiveRecord::Migration
+  def change
+    change_column :answers, :run_time, :float, :default => 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150812034259) do
+ActiveRecord::Schema.define(version: 20151005063504) do
 
   create_table "answers", force: :cascade do |t|
     t.integer  "student_id",            limit: 4,                 null: false

--- a/lib/evaluate_program.rb
+++ b/lib/evaluate_program.rb
@@ -3,11 +3,11 @@ module EvaluateProgram
   # 失敗時の処理
   # @param [Answer] answer 保存するAnswerオブジェクト
   # @param [String] result resultに記録する文字列
-  # @param [String] filename 一時保存のファイル名
-  def cancel_evaluate(answer, result, filename)
+  # @param [String] dirname 作業ディレクトリ
+  def cancel_evaluate(answer, result, dirname)
     answer.result = result
     answer.save
-    `rm #{filename}*`
+    `rm -r #{dirname}`
     return
   end
 


### PR DESCRIPTION
# 概要
- C言語，C++言語用のサンドボックス環境をdockerで構築
- 基本はpythonと同様だが，コンパイル時はコンテナを使用しない
- production環境で起動時は，Dockerfileを取得してきてbuildする
# 変更点
- C用のジョブにdockerでの実行に変更
# 使い方
- コンテナイメージをbuildしておく
- 今まで通りC, C++プログラムをアップロードする
